### PR TITLE
Remove PostGoals, and rename PreGoals to SubGoals

### DIFF
--- a/cmd/ddenv/main.go
+++ b/cmd/ddenv/main.go
@@ -127,12 +127,6 @@ func flattenGoals(out []core.Goal, inGoal core.Goal) []core.Goal {
 
 	out = append(out, inGoal)
 
-	if withPostGoals, ok := inGoal.(core.WithPostGoals); ok {
-		for _, g := range withPostGoals.PostGoals() {
-			out = flattenGoals(out, g)
-		}
-	}
-
 	return out
 }
 

--- a/cmd/ddenv/main.go
+++ b/cmd/ddenv/main.go
@@ -119,8 +119,8 @@ func ReadGoals() ([]core.Goal, error) {
 }
 
 func flattenGoals(out []core.Goal, inGoal core.Goal) []core.Goal {
-	if withPreGoals, ok := inGoal.(core.WithPreGoals); ok {
-		for _, g := range withPreGoals.PreGoals() {
+	if withSubGoals, ok := inGoal.(core.WithSubGoals); ok {
+		for _, g := range withSubGoals.SubGoals() {
 			out = flattenGoals(out, g)
 		}
 	}

--- a/cmd/ddenv/main.go
+++ b/cmd/ddenv/main.go
@@ -217,13 +217,18 @@ func main() {
 		colDelta := maxDescriptionLen + 2
 
 		updateStatus(rowDelta, colDelta, "checking...")
-		isAchieved := goal.IsAchieved()
+		var isAchieved = true
+		if withAchieve, ok := goal.(core.WithAchieve); ok {
+			isAchieved = withAchieve.IsAchieved()
+		}
 
 		if isAchieved {
 			updateStatus(rowDelta, colDelta, "skipped")
 		} else {
 			updateStatus(rowDelta, colDelta, "working...")
-			err = goal.Achieve()
+			if withAchieve, ok := goal.(core.WithAchieve); ok {
+				err = withAchieve.Achieve()
+			}
 			if err != nil {
 				updateStatus(rowDelta, colDelta, fmt.Sprintf("%v%v%v", red, "failed", reset))
 				fmt.Printf("\n%v%v%v", red, err, reset)

--- a/core/core.go
+++ b/core/core.go
@@ -16,10 +16,6 @@ type WithPreGoals interface {
 	PreGoals() []Goal
 }
 
-type WithPostGoals interface {
-	PostGoals() []Goal
-}
-
 var goalFnsByName map[string]func(value interface{}) (Goal, error)
 
 func init() {

--- a/core/core.go
+++ b/core/core.go
@@ -5,6 +5,9 @@ import "fmt"
 type Goal interface {
 	Description() string
 	HashIdentity() string
+}
+
+type WithAchieve interface {
 	IsAchieved() bool
 	Achieve() error
 }

--- a/core/core.go
+++ b/core/core.go
@@ -12,8 +12,8 @@ type WithAchieve interface {
 	Achieve() error
 }
 
-type WithPreGoals interface {
-	PreGoals() []Goal
+type WithSubGoals interface {
+	SubGoals() []Goal
 }
 
 var goalFnsByName map[string]func(value interface{}) (Goal, error)

--- a/goals/bundle_installed.go
+++ b/goals/bundle_installed.go
@@ -43,7 +43,7 @@ func (g BundleInstalled) Achieve() error {
 	return nil
 }
 
-func (g BundleInstalled) PreGoals() []core.Goal {
+func (g BundleInstalled) SubGoals() []core.Goal {
 	return []core.Goal{
 		GemInstalled{Name: "bundler"},
 	}

--- a/goals/node_installed.go
+++ b/goals/node_installed.go
@@ -38,7 +38,7 @@ func (g NodeInstalled) Achieve() error {
 	return nil
 }
 
-func (g NodeInstalled) PreGoals() []core.Goal {
+func (g NodeInstalled) SubGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: "node-build"},
 	}

--- a/goals/node_installed.go
+++ b/goals/node_installed.go
@@ -6,21 +6,9 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"strings"
 
 	"denisdefreyne.com/x/ddenv/core"
 )
-
-func init() {
-	core.RegisterGoal("node", func(value interface{}) (core.Goal, error) {
-		if nodeVersionBytes, err := os.ReadFile(".node-version"); err != nil {
-			return nil, fmt.Errorf("expected .node-version to exist")
-		} else {
-			nodeVersionString := strings.TrimSpace(string(nodeVersionBytes))
-			return NodeInstalled{Version: nodeVersionString}, nil
-		}
-	})
-}
 
 type NodeInstalled struct {
 	Version string
@@ -53,12 +41,6 @@ func (g NodeInstalled) Achieve() error {
 func (g NodeInstalled) PreGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: "node-build"},
-	}
-}
-
-func (g NodeInstalled) PostGoals() []core.Goal {
-	return []core.Goal{
-		NodeShadowenvCreated{Version: g.Version, Path: g.path()},
 	}
 }
 

--- a/goals/node_set_up.go
+++ b/goals/node_set_up.go
@@ -31,7 +31,7 @@ func (g NodeSetUp) HashIdentity() string {
 	return fmt.Sprintf("NodeSetUp %v", g)
 }
 
-func (g NodeSetUp) PreGoals() []core.Goal {
+func (g NodeSetUp) SubGoals() []core.Goal {
 	nodeInstalledGoal := NodeInstalled{Version: g.Version}
 
 	return []core.Goal{

--- a/goals/node_set_up.go
+++ b/goals/node_set_up.go
@@ -1,0 +1,41 @@
+package goals
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"denisdefreyne.com/x/ddenv/core"
+)
+
+func init() {
+	core.RegisterGoal("node", func(value interface{}) (core.Goal, error) {
+		if nodeVersionBytes, err := os.ReadFile(".node-version"); err != nil {
+			return nil, fmt.Errorf("expected .node-version to exist")
+		} else {
+			nodeVersionString := strings.TrimSpace(string(nodeVersionBytes))
+			return NodeSetUp{Version: nodeVersionString}, nil
+		}
+	})
+}
+
+type NodeSetUp struct {
+	Version string
+}
+
+func (g NodeSetUp) Description() string {
+	return fmt.Sprintf("Setting up Node %v", g.Version)
+}
+
+func (g NodeSetUp) HashIdentity() string {
+	return fmt.Sprintf("NodeSetUp %v", g)
+}
+
+func (g NodeSetUp) PreGoals() []core.Goal {
+	nodeInstalledGoal := NodeInstalled{Version: g.Version}
+
+	return []core.Goal{
+		nodeInstalledGoal,
+		NodeShadowenvCreated{Version: g.Version, Path: nodeInstalledGoal.path()},
+	}
+}

--- a/goals/node_shadowenv_created.go
+++ b/goals/node_shadowenv_created.go
@@ -61,7 +61,7 @@ func (g NodeShadowenvCreated) Achieve() error {
 
 func (g NodeShadowenvCreated) PreGoals() []core.Goal {
 	return []core.Goal{
-		ShadowenvDirCreated{},
+		ShadowenvSetUp{},
 	}
 }
 

--- a/goals/node_shadowenv_created.go
+++ b/goals/node_shadowenv_created.go
@@ -59,7 +59,7 @@ func (g NodeShadowenvCreated) Achieve() error {
 	return nil
 }
 
-func (g NodeShadowenvCreated) PreGoals() []core.Goal {
+func (g NodeShadowenvCreated) SubGoals() []core.Goal {
 	return []core.Goal{
 		ShadowenvSetUp{},
 	}

--- a/goals/postgresql_set_up.go
+++ b/goals/postgresql_set_up.go
@@ -63,7 +63,7 @@ func (g PostgresqlSetUp) HashIdentity() string {
 	return fmt.Sprintf("PostgresqlSetUp %v", g)
 }
 
-func (g PostgresqlSetUp) PreGoals() []core.Goal {
+func (g PostgresqlSetUp) SubGoals() []core.Goal {
 	return []core.Goal{
 		PostgresqlStarted{Version: g.Version, Env: g.Env},
 		PostgresqlShadowenvCreated{Version: g.Version, Env: g.Env},

--- a/goals/postgresql_set_up.go
+++ b/goals/postgresql_set_up.go
@@ -65,7 +65,6 @@ func (g PostgresqlSetUp) HashIdentity() string {
 
 func (g PostgresqlSetUp) PreGoals() []core.Goal {
 	return []core.Goal{
-		HomebrewPackageInstalled{PackageName: g.homebrewPackageName()},
 		PostgresqlStarted{Version: g.Version, Env: g.Env},
 		PostgresqlShadowenvCreated{Version: g.Version, Env: g.Env},
 	}

--- a/goals/postgresql_set_up.go
+++ b/goals/postgresql_set_up.go
@@ -1,0 +1,76 @@
+package goals
+
+import (
+	"fmt"
+
+	"denisdefreyne.com/x/ddenv/core"
+)
+
+func init() {
+	core.RegisterGoal("postgresql", func(value interface{}) (core.Goal, error) {
+		detailsMap, ok := value.(map[interface{}]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected details map")
+		}
+
+		// Get version
+		version, ok := detailsMap["version"]
+		if !ok {
+			return nil, fmt.Errorf("expected version")
+		}
+		intVersion, ok := version.(int)
+		if !ok {
+			return nil, fmt.Errorf("expected integer version")
+		}
+
+		// Get env
+		rawEnv, ok := detailsMap["env"]
+		env := make(map[string]string)
+		if ok {
+			if typedEnv, ok := rawEnv.(map[interface{}]interface{}); !ok {
+				return nil, fmt.Errorf("expected env to be a map")
+			} else {
+				for rawKey, rawValue := range typedEnv {
+					if key, ok := rawKey.(string); ok {
+						if value, ok := rawValue.(string); ok {
+							env[key] = value
+						} else {
+							return nil, fmt.Errorf("expected env values to be strings")
+						}
+					} else {
+						return nil, fmt.Errorf("expected env keys to be strings")
+					}
+				}
+			}
+		}
+
+		g := PostgresqlSetUp{Version: intVersion, Env: env}
+
+		return g, nil
+	})
+}
+
+type PostgresqlSetUp struct {
+	Version int
+	Env     map[string]string
+}
+
+func (g PostgresqlSetUp) Description() string {
+	return fmt.Sprintf("Setting up PostgreSQL %v", g.Version)
+}
+
+func (g PostgresqlSetUp) HashIdentity() string {
+	return fmt.Sprintf("PostgresqlSetUp %v", g)
+}
+
+func (g PostgresqlSetUp) PreGoals() []core.Goal {
+	return []core.Goal{
+		HomebrewPackageInstalled{PackageName: g.homebrewPackageName()},
+		PostgresqlStarted{Version: g.Version, Env: g.Env},
+		PostgresqlShadowenvCreated{Version: g.Version, Env: g.Env},
+	}
+}
+
+func (g PostgresqlSetUp) homebrewPackageName() string {
+	return fmt.Sprintf("postgresql@%v", g.Version)
+}

--- a/goals/postgresql_shadowenv_created.go
+++ b/goals/postgresql_shadowenv_created.go
@@ -59,7 +59,7 @@ func (g PostgresqlShadowenvCreated) Achieve() error {
 	return nil
 }
 
-func (g PostgresqlShadowenvCreated) PreGoals() []core.Goal {
+func (g PostgresqlShadowenvCreated) SubGoals() []core.Goal {
 	return []core.Goal{
 		ShadowenvSetUp{},
 	}

--- a/goals/postgresql_shadowenv_created.go
+++ b/goals/postgresql_shadowenv_created.go
@@ -61,7 +61,7 @@ func (g PostgresqlShadowenvCreated) Achieve() error {
 
 func (g PostgresqlShadowenvCreated) PreGoals() []core.Goal {
 	return []core.Goal{
-		ShadowenvDirCreated{},
+		ShadowenvSetUp{},
 	}
 }
 

--- a/goals/postgresql_started.go
+++ b/goals/postgresql_started.go
@@ -9,50 +9,6 @@ import (
 	"denisdefreyne.com/x/ddenv/homebrew"
 )
 
-func init() {
-	core.RegisterGoal("postgresql", func(value interface{}) (core.Goal, error) {
-		detailsMap, ok := value.(map[interface{}]interface{})
-		if !ok {
-			return nil, fmt.Errorf("expected details map")
-		}
-
-		// Get version
-		version, ok := detailsMap["version"]
-		if !ok {
-			return nil, fmt.Errorf("expected version")
-		}
-		intVersion, ok := version.(int)
-		if !ok {
-			return nil, fmt.Errorf("expected integer version")
-		}
-
-		// Get env
-		rawEnv, ok := detailsMap["env"]
-		env := make(map[string]string)
-		if ok {
-			if typedEnv, ok := rawEnv.(map[interface{}]interface{}); !ok {
-				return nil, fmt.Errorf("expected env to be a map")
-			} else {
-				for rawKey, rawValue := range typedEnv {
-					if key, ok := rawKey.(string); ok {
-						if value, ok := rawValue.(string); ok {
-							env[key] = value
-						} else {
-							return nil, fmt.Errorf("expected env values to be strings")
-						}
-					} else {
-						return nil, fmt.Errorf("expected env keys to be strings")
-					}
-				}
-			}
-		}
-
-		g := PostgresqlStarted{Version: intVersion, Env: env}
-
-		return g, nil
-	})
-}
-
 type PostgresqlStarted struct {
 	Version int
 	Env     map[string]string
@@ -104,12 +60,6 @@ func (g PostgresqlStarted) Achieve() error {
 func (g PostgresqlStarted) PreGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: g.homebrewPackageName()},
-	}
-}
-
-func (g PostgresqlStarted) PostGoals() []core.Goal {
-	return []core.Goal{
-		PostgresqlShadowenvCreated{Version: g.Version, Env: g.Env},
 	}
 }
 

--- a/goals/postgresql_started.go
+++ b/goals/postgresql_started.go
@@ -57,7 +57,7 @@ func (g PostgresqlStarted) Achieve() error {
 	return nil
 }
 
-func (g PostgresqlStarted) PreGoals() []core.Goal {
+func (g PostgresqlStarted) SubGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: g.homebrewPackageName()},
 	}

--- a/goals/redis_set_up.go
+++ b/goals/redis_set_up.go
@@ -52,7 +52,7 @@ func (g RedisSetUp) HashIdentity() string {
 	return fmt.Sprintf("RedisSetUp %v", g)
 }
 
-func (g RedisSetUp) PreGoals() []core.Goal {
+func (g RedisSetUp) SubGoals() []core.Goal {
 	return []core.Goal{
 		RedisStarted{Env: g.Env},
 		RedisShadowenvCreated{Env: g.Env},

--- a/goals/redis_set_up.go
+++ b/goals/redis_set_up.go
@@ -1,0 +1,60 @@
+package goals
+
+import (
+	"fmt"
+
+	"denisdefreyne.com/x/ddenv/core"
+)
+
+func init() {
+	core.RegisterGoal("redis", func(value interface{}) (core.Goal, error) {
+		detailsMap, ok := value.(map[interface{}]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected details map")
+		}
+
+		// Get env
+		rawEnv, ok := detailsMap["env"]
+		env := make(map[string]string)
+		if ok {
+			if typedEnv, ok := rawEnv.(map[interface{}]interface{}); !ok {
+				return nil, fmt.Errorf("expected env to be a map")
+			} else {
+				for rawKey, rawValue := range typedEnv {
+					if key, ok := rawKey.(string); ok {
+						if value, ok := rawValue.(string); ok {
+							env[key] = value
+						} else {
+							return nil, fmt.Errorf("expected env values to be strings")
+						}
+					} else {
+						return nil, fmt.Errorf("expected env keys to be strings")
+					}
+				}
+			}
+		}
+
+		g := RedisSetUp{Env: env}
+
+		return g, nil
+	})
+}
+
+type RedisSetUp struct {
+	Env map[string]string
+}
+
+func (g RedisSetUp) Description() string {
+	return fmt.Sprintf("Setting up Redis")
+}
+
+func (g RedisSetUp) HashIdentity() string {
+	return fmt.Sprintf("RedisSetUp %v", g)
+}
+
+func (g RedisSetUp) PreGoals() []core.Goal {
+	return []core.Goal{
+		RedisStarted{Env: g.Env},
+		RedisShadowenvCreated{Env: g.Env},
+	}
+}

--- a/goals/redis_shadowenv_created.go
+++ b/goals/redis_shadowenv_created.go
@@ -60,7 +60,7 @@ func (g RedisShadowenvCreated) Achieve() error {
 
 func (g RedisShadowenvCreated) PreGoals() []core.Goal {
 	return []core.Goal{
-		ShadowenvDirCreated{},
+		ShadowenvSetUp{},
 	}
 }
 

--- a/goals/redis_shadowenv_created.go
+++ b/goals/redis_shadowenv_created.go
@@ -58,7 +58,7 @@ func (g RedisShadowenvCreated) Achieve() error {
 	return nil
 }
 
-func (g RedisShadowenvCreated) PreGoals() []core.Goal {
+func (g RedisShadowenvCreated) SubGoals() []core.Goal {
 	return []core.Goal{
 		ShadowenvSetUp{},
 	}

--- a/goals/redis_started.go
+++ b/goals/redis_started.go
@@ -18,7 +18,7 @@ func (g RedisStarted) HashIdentity() string {
 	return fmt.Sprintf("RedisStarted %v", g)
 }
 
-func (g RedisStarted) PreGoals() []core.Goal {
+func (g RedisStarted) SubGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: "redis"},
 	}

--- a/goals/redis_started.go
+++ b/goals/redis_started.go
@@ -2,45 +2,9 @@ package goals
 
 import (
 	"fmt"
-	"os/exec"
 
 	"denisdefreyne.com/x/ddenv/core"
-	"denisdefreyne.com/x/ddenv/homebrew"
 )
-
-func init() {
-	core.RegisterGoal("redis", func(value interface{}) (core.Goal, error) {
-		detailsMap, ok := value.(map[interface{}]interface{})
-		if !ok {
-			return nil, fmt.Errorf("expected details map")
-		}
-
-		// Get env
-		rawEnv, ok := detailsMap["env"]
-		env := make(map[string]string)
-		if ok {
-			if typedEnv, ok := rawEnv.(map[interface{}]interface{}); !ok {
-				return nil, fmt.Errorf("expected env to be a map")
-			} else {
-				for rawKey, rawValue := range typedEnv {
-					if key, ok := rawKey.(string); ok {
-						if value, ok := rawValue.(string); ok {
-							env[key] = value
-						} else {
-							return nil, fmt.Errorf("expected env values to be strings")
-						}
-					} else {
-						return nil, fmt.Errorf("expected env keys to be strings")
-					}
-				}
-			}
-		}
-
-		g := RedisStarted{Env: env}
-
-		return g, nil
-	})
-}
 
 type RedisStarted struct {
 	Env map[string]string
@@ -54,39 +18,8 @@ func (g RedisStarted) HashIdentity() string {
 	return fmt.Sprintf("RedisStarted %v", g)
 }
 
-func (g RedisStarted) IsAchieved() bool {
-	brewServicesListEntries, err := homebrew.ServiceInfoFor("redis")
-	if err != nil {
-		return false
-	}
-
-	// Check
-	if len(brewServicesListEntries) > 0 {
-		return brewServicesListEntries[0].Status == "started"
-	}
-
-	return false
-}
-
-func (g RedisStarted) Achieve() error {
-	cmd := exec.Command("brew", "services", "start", "redis")
-
-	stdoutStderr, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%v\n\n%v", err, string(stdoutStderr))
-	}
-
-	return nil
-}
-
 func (g RedisStarted) PreGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: "redis"},
-	}
-}
-
-func (g RedisStarted) PostGoals() []core.Goal {
-	return []core.Goal{
-		RedisShadowenvCreated{Env: g.Env},
 	}
 }

--- a/goals/ruby_installed.go
+++ b/goals/ruby_installed.go
@@ -7,21 +7,9 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"denisdefreyne.com/x/ddenv/core"
 )
-
-func init() {
-	core.RegisterGoal("ruby", func(value interface{}) (core.Goal, error) {
-		if rubyVersionBytes, err := os.ReadFile(".ruby-version"); err != nil {
-			return nil, fmt.Errorf("expected .ruby-version to exist")
-		} else {
-			rubyVersionString := strings.TrimSpace(string(rubyVersionBytes))
-			return RubyInstalled{Version: rubyVersionString}, nil
-		}
-	})
-}
 
 type RubyInstalled struct {
 	Version string
@@ -54,12 +42,6 @@ func (g RubyInstalled) Achieve() error {
 func (g RubyInstalled) PreGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: "ruby-install"},
-	}
-}
-
-func (g RubyInstalled) PostGoals() []core.Goal {
-	return []core.Goal{
-		RubyShadowenvCreated{Version: g.Version, Path: g.path()},
 	}
 }
 

--- a/goals/ruby_installed.go
+++ b/goals/ruby_installed.go
@@ -39,7 +39,7 @@ func (g RubyInstalled) Achieve() error {
 	return nil
 }
 
-func (g RubyInstalled) PreGoals() []core.Goal {
+func (g RubyInstalled) SubGoals() []core.Goal {
 	return []core.Goal{
 		HomebrewPackageInstalled{PackageName: "ruby-install"},
 	}

--- a/goals/ruby_installed_and_available.go
+++ b/goals/ruby_installed_and_available.go
@@ -1,0 +1,51 @@
+package goals
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"denisdefreyne.com/x/ddenv/core"
+)
+
+func init() {
+	core.RegisterGoal("ruby", func(value interface{}) (core.Goal, error) {
+		if rubyVersionBytes, err := os.ReadFile(".ruby-version"); err != nil {
+			return nil, fmt.Errorf("expected .ruby-version to exist")
+		} else {
+			rubyVersionString := strings.TrimSpace(string(rubyVersionBytes))
+			return RubyInstalledAndAvailable{Version: rubyVersionString}, nil
+		}
+	})
+}
+
+type RubyInstalledAndAvailable struct {
+	Version string
+}
+
+func (g RubyInstalledAndAvailable) Description() string {
+	return fmt.Sprintf("Setting up Ruby %v", g.Version)
+}
+
+func (g RubyInstalledAndAvailable) HashIdentity() string {
+	return fmt.Sprintf("RubyInstalledAndAvailable %v", g)
+}
+
+func (g RubyInstalledAndAvailable) IsAchieved() bool {
+	// TODO: weird non-goal
+	return false
+}
+
+func (g RubyInstalledAndAvailable) Achieve() error {
+	// TODO: weird non-goal
+	return nil
+}
+
+func (g RubyInstalledAndAvailable) PreGoals() []core.Goal {
+	rubyInstalledGoal := RubyInstalled{Version: g.Version}
+
+	return []core.Goal{
+		rubyInstalledGoal,
+		RubyShadowenvCreated{Version: g.Version, Path: rubyInstalledGoal.path()},
+	}
+}

--- a/goals/ruby_installed_and_available.go
+++ b/goals/ruby_installed_and_available.go
@@ -31,16 +31,6 @@ func (g RubyInstalledAndAvailable) HashIdentity() string {
 	return fmt.Sprintf("RubyInstalledAndAvailable %v", g)
 }
 
-func (g RubyInstalledAndAvailable) IsAchieved() bool {
-	// TODO: weird non-goal
-	return false
-}
-
-func (g RubyInstalledAndAvailable) Achieve() error {
-	// TODO: weird non-goal
-	return nil
-}
-
 func (g RubyInstalledAndAvailable) PreGoals() []core.Goal {
 	rubyInstalledGoal := RubyInstalled{Version: g.Version}
 

--- a/goals/ruby_set_up.go
+++ b/goals/ruby_set_up.go
@@ -31,7 +31,7 @@ func (g RubySetUp) HashIdentity() string {
 	return fmt.Sprintf("RubySetUp %v", g)
 }
 
-func (g RubySetUp) PreGoals() []core.Goal {
+func (g RubySetUp) SubGoals() []core.Goal {
 	rubyInstalledGoal := RubyInstalled{Version: g.Version}
 
 	return []core.Goal{

--- a/goals/ruby_set_up.go
+++ b/goals/ruby_set_up.go
@@ -14,24 +14,24 @@ func init() {
 			return nil, fmt.Errorf("expected .ruby-version to exist")
 		} else {
 			rubyVersionString := strings.TrimSpace(string(rubyVersionBytes))
-			return RubyInstalledAndAvailable{Version: rubyVersionString}, nil
+			return RubySetUp{Version: rubyVersionString}, nil
 		}
 	})
 }
 
-type RubyInstalledAndAvailable struct {
+type RubySetUp struct {
 	Version string
 }
 
-func (g RubyInstalledAndAvailable) Description() string {
+func (g RubySetUp) Description() string {
 	return fmt.Sprintf("Setting up Ruby %v", g.Version)
 }
 
-func (g RubyInstalledAndAvailable) HashIdentity() string {
-	return fmt.Sprintf("RubyInstalledAndAvailable %v", g)
+func (g RubySetUp) HashIdentity() string {
+	return fmt.Sprintf("RubySetUp %v", g)
 }
 
-func (g RubyInstalledAndAvailable) PreGoals() []core.Goal {
+func (g RubySetUp) PreGoals() []core.Goal {
 	rubyInstalledGoal := RubyInstalled{Version: g.Version}
 
 	return []core.Goal{

--- a/goals/ruby_shadowenv_created.go
+++ b/goals/ruby_shadowenv_created.go
@@ -61,7 +61,7 @@ func (g RubyShadowenvCreated) Achieve() error {
 
 func (g RubyShadowenvCreated) PreGoals() []core.Goal {
 	return []core.Goal{
-		ShadowenvDirCreated{},
+		ShadowenvSetUp{},
 	}
 }
 

--- a/goals/ruby_shadowenv_created.go
+++ b/goals/ruby_shadowenv_created.go
@@ -59,7 +59,7 @@ func (g RubyShadowenvCreated) Achieve() error {
 	return nil
 }
 
-func (g RubyShadowenvCreated) PreGoals() []core.Goal {
+func (g RubyShadowenvCreated) SubGoals() []core.Goal {
 	return []core.Goal{
 		ShadowenvSetUp{},
 	}

--- a/goals/shadowenv_dir_created.go
+++ b/goals/shadowenv_dir_created.go
@@ -3,8 +3,6 @@ package goals
 import (
 	"fmt"
 	"os"
-
-	"denisdefreyne.com/x/ddenv/core"
 )
 
 const ShadowenvDirCreated_Path = ".shadowenv.d"
@@ -27,17 +25,4 @@ func (g ShadowenvDirCreated) IsAchieved() bool {
 func (g ShadowenvDirCreated) Achieve() error {
 	err := os.Mkdir(ShadowenvDirCreated_Path, 0755)
 	return err
-}
-
-func (g ShadowenvDirCreated) PreGoals() []core.Goal {
-	return []core.Goal{
-		ShadowenvInitialized{},
-	}
-}
-
-func (g ShadowenvDirCreated) PostGoals() []core.Goal {
-	return []core.Goal{
-		ShadowenvDirGitIgnored{},
-		ShadowenvTrusted{},
-	}
 }

--- a/goals/shadowenv_set_up.go
+++ b/goals/shadowenv_set_up.go
@@ -29,7 +29,7 @@ func (g ShadowenvSetUp) Achieve() error {
 	return err
 }
 
-func (g ShadowenvSetUp) PreGoals() []core.Goal {
+func (g ShadowenvSetUp) SubGoals() []core.Goal {
 	return []core.Goal{
 		ShadowenvInitialized{},
 		ShadowenvDirCreated{},

--- a/goals/shadowenv_set_up.go
+++ b/goals/shadowenv_set_up.go
@@ -1,0 +1,39 @@
+package goals
+
+import (
+	"fmt"
+	"os"
+
+	"denisdefreyne.com/x/ddenv/core"
+)
+
+const ShadowenvSetUp_Path = ".shadowenv.d"
+
+type ShadowenvSetUp struct{}
+
+func (g ShadowenvSetUp) Description() string {
+	return "Setting up Shadowenv"
+}
+
+func (g ShadowenvSetUp) HashIdentity() string {
+	return fmt.Sprintf("ShadowenvSetUp %v", g)
+}
+
+func (g ShadowenvSetUp) IsAchieved() bool {
+	_, err := os.Lstat(ShadowenvSetUp_Path)
+	return err == nil
+}
+
+func (g ShadowenvSetUp) Achieve() error {
+	err := os.Mkdir(ShadowenvSetUp_Path, 0755)
+	return err
+}
+
+func (g ShadowenvSetUp) PreGoals() []core.Goal {
+	return []core.Goal{
+		ShadowenvInitialized{},
+		ShadowenvDirCreated{},
+		ShadowenvDirGitIgnored{},
+		ShadowenvTrusted{},
+	}
+}


### PR DESCRIPTION
The concept of “post goal” was confusing and, I realize now, a bit of a lazy workaround.

`PostGoals` are gone entirely. Instead, there are higher-level goals that flip the dependency, e.g. `RubyInstalled` no longer has a `PostGoal` of `RubyShadowenvCreated`, but there rather is a `RubySetUp` goal that has `RubyInstalled` and `RubyShadowenvCreated` pre-goals/sub-goals.

With `PostGoals` gone, `PreGoals` are renamed to `SubGoals`.

Goals no longer need `Achieve` and `IsAchieved`, which is helpful for meta-goals.

While this set-up is slightly more verbose, it is also simpler.